### PR TITLE
fix: 避免 assertBodySize 消耗请求体导致多文件上传失败

### DIFF
--- a/packages/server/routes/api/backups/restore-upload.post.ts
+++ b/packages/server/routes/api/backups/restore-upload.post.ts
@@ -1,7 +1,7 @@
 import {
-  assertBodySize,
   createError,
   defineEventHandler,
+  getHeader,
   readMultipartFormData
 } from "h3";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -14,7 +14,13 @@ import { getRequestUser } from "../../../utils/request-user";
 const maxUploadedBackupBytes = 1024 * 1024 * 1024;
 
 export default defineEventHandler(async (event) => {
-  await assertBodySize(event, maxUploadedBackupBytes);
+  const contentLength = Number(getHeader(event, "content-length") || 0);
+  if (contentLength > maxUploadedBackupBytes) {
+    throw createError({
+      statusCode: 413,
+      statusMessage: `备份文件大小超过限制（最大 ${Math.round(maxUploadedBackupBytes / 1024 / 1024)}MB）`
+    });
+  }
   const parts = await readMultipartFormData(event);
   const backup = parts.find((part) => (part.name === "backup" || part.name === "file") && part.filename);
   if (!backup?.filename) throw createError({ statusCode: 400, statusMessage: "请选择备份文件" });

--- a/packages/server/routes/api/uploads.post.ts
+++ b/packages/server/routes/api/uploads.post.ts
@@ -1,7 +1,7 @@
 import {
-  assertBodySize,
   createError,
   defineEventHandler,
+  getHeader,
   readMultipartFormData,
   setResponseStatus
 } from "h3";
@@ -17,7 +17,16 @@ function textPart(parts: Awaited<ReturnType<typeof readMultipartFormData>>, name
 }
 
 export default defineEventHandler(async (event) => {
-  await assertBodySize(event, maxRequestBytes);
+  // NOTE: 不使用 h3 的 assertBodySize — 它会通过 req.clone() 读取整个请求体来测量大小，
+  // 而 srvx 的 clone() 实现与原始请求共享 body stream，导致后续 readMultipartFormData
+  // 报 "Body has already been read" 错误。改为仅检查 Content-Length header。
+  const contentLength = Number(getHeader(event, "content-length") || 0);
+  if (contentLength > maxRequestBytes) {
+    throw createError({
+      statusCode: 413,
+      statusMessage: `请求体大小超过限制（最大 ${Math.round(maxRequestBytes / 1024 / 1024)}MB）`
+    });
+  }
   const parts = await readMultipartFormData(event);
   const memberId = textPart(parts, "memberId").trim();
   if (!memberId) throw createError({ statusCode: 400, statusMessage: "请选择报告所属成员" });


### PR DESCRIPTION
h3 v2 的 assertBodySize() 内部通过 req.clone().body.getReader() 读取整个请求体来测量大小。srvx 的 clone() 实现中克隆体与原始请求
共享同一个 body stream，导致后续 readMultipartFormData() 调用
formData() 时报错 'Body has already been read'。

修复方案：将 assertBodySize 替换为仅检查 Content-Length header 的 轻量校验，不读取请求体。

影响路由：
- POST /api/uploads（上传报告）
- POST /api/backups/restore-upload（恢复备份上传）

Fixes #1